### PR TITLE
Fix/docker cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# 無視するファイルやディレクトリを指定
+
+# Git 関連のファイルを除外
+.git
+.gitignore
+
+# Python キャッシュファイルを除外
+__pycache__/
+*.py[cod]
+
+# ビルドや開発に不要なディレクトリを除外
+build/
+dist/
+eggs/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+develop-eggs/
+.tox/
+.venv/
+.env/
+env/
+venv/
+ENV/
+.eggs/
+*.egg-info/
+.cache/
+.pytest_cache/
+
+# 大きなファイルやディレクトリを除外
+*.pt
+*.pth
+*.onnx
+data/
+logs/
+models/
+checkpoints/
+outputs/

--- a/.github/workflows/process_models.yml
+++ b/.github/workflows/process_models.yml
@@ -18,23 +18,6 @@ jobs:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v4.2.2
 
-      - name: 古い順に処理すべきIssueを取得
-        id: get_issues
-        uses: actions/github-script@v7.0.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const issues = await github.paginate(github.rest.issues.listForRepo, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: '',  // ラベルが付いていないIssueのみ取得
-              per_page: 100,
-            });
-            // Pull Requestを除外し、タイトルにモデル名が記載されているIssueをフィルタリング
-            const modelIssues = issues.filter(issue => issue.title && !issue.pull_request);
-            core.setOutput('issues', JSON.stringify(modelIssues));
-
       # === Docker Buildx のセットアップ ===
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0
@@ -74,29 +57,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Issuesのリストをファイルに保存
-        run: |
-          echo '${{ steps.get_issues.outputs.issues }}' > issues.json
-
       - name: モデルの処理（Dockerコンテナ内で実行）
-        if: steps.get_issues.outputs.issues != '[]'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          USERNAME: ort-community
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
           docker run --rm \
-            -v ${{ github.workspace }}/issues.json:/app/issues.json \
             -e HF_TOKEN \
             -e GITHUB_TOKEN \
-            -e USERNAME \
             -e REPOSITORY \
             -e RUN_ID \
             model-processor \
-            python process_issues.py "/app/issues.json" "$REPOSITORY" "$RUN_ID"
+            python process_issues.py "$REPOSITORY" "$RUN_ID"
 
       - name: 完了メッセージ
-        if: steps.get_issues.outputs.issues == '[]'
-        run: echo "処理すべきIssueはありません。"
+        run: echo "モデルの処理が完了しました。"

--- a/.github/workflows/process_models.yml
+++ b/.github/workflows/process_models.yml
@@ -35,9 +35,44 @@ jobs:
             const modelIssues = issues.filter(issue => issue.title && !issue.pull_request);
             core.setOutput('issues', JSON.stringify(modelIssues));
 
+      # === Docker Buildx のセットアップ ===
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3.8.0
+
+      # === Docker キャッシュの復元 ===
+      - name: キャッシュの復元
+        id: cache-docker
+        uses: actions/cache@v4.2.0
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # === Docker イメージのビルド ===
       - name: Dockerイメージのビルド
-        run: |
-          docker build -t model-processor .
+        uses: docker/build-push-action@v6.10.0
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: model-processor:latest
+          load: true  # ローカルにイメージをロード
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # === Docker キャッシュの保存 ===
+      - name: キャッシュの保存
+        if: always()
+        uses: actions/cache@v4.2.0
+        with:
+          path: /tmp/.buildx-cache-new
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Issuesのリストをファイルに保存
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,19 +16,22 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
     signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
     https://cli.github.com/packages stable main" > \
     /etc/apt/sources.list.d/github-cli.list && \
-    apt-get update && apt-get install -y gh && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
     rm -rf /var/lib/apt/lists/*
 
 # 作業ディレクトリを設定
 WORKDIR /app
 
-# ソースコードをコピー
-COPY . /app
+# 必要なファイルのみをコピー
+COPY requirements.txt ./
+COPY process_issues.py ./
+# 他に必要なファイルがあれば、ここで個別にコピーします
+# 例: COPY src/ ./src/
 
 # ライブラリのインストール
 RUN pip install --no-cache-dir --upgrade pip
 
-# PyTorchのインストール（CPU版の軽量ホイールを指定）
+# PyTorch のインストール（CPU 版の軽量ホイールを指定）
 RUN pip install --no-cache-dir https://download.pytorch.org/whl/cpu/torch-2.1.0%2Bcpu-cp311-cp311-linux_x86_64.whl
 
 # 他の依存関係をインストール
@@ -37,27 +40,43 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ランタイムステージ
 FROM python:3.11-slim
 
-# 作業ディレクトリを設定
-WORKDIR /app
-
-# ビルドステージから必要なファイルをコピー
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
-
-# ソースコードをコピー
-COPY . /app
-
-# 依存関係に必要なランタイムライブラリをインストール（必要に応じて）
+# 必要なランタイムパッケージをインストール
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # ランタイムに必要なパッケージをここに記載
     libglib2.0-0 \
     libsm6 \
     libxrender1 \
     libxext6 \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
+# GitHub CLI のインストール
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+    dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) \
+    signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+    https://cli.github.com/packages stable main" > \
+    /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# ビルドステージから必要なファイルをコピー
+COPY --from=builder /usr/local /usr/local
+
+# 必要なファイルのみをコピー
+COPY process_issues.py ./
+# 他に必要なファイルがあれば、ここで個別にコピーします
+# 例: COPY src/ ./src/
+
 # キャッシュの削除（念のため）
-RUN rm -rf ~/.cache/pip
+RUN rm -rf /root/.cache/pip \
+    && find /usr/local/lib/python3.11/site-packages/ -name '__pycache__' -exec rm -rf {} + \
+    && find /usr/local/lib/python3.11/site-packages/ -type d -name 'tests' -exec rm -rf {} + \
+    && find /usr/local/lib/python3.11/site-packages/ -name '*.pyc' -delete \
+    && rm -rf /usr/local/lib/python3.11/site-packages/**/*.dist-info
 
 # エントリーポイントを設定（オプション）
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,15 @@ WORKDIR /app
 # 必要なファイルのみをコピー
 COPY requirements.txt ./
 COPY process_issues.py ./
-# 他に必要なファイルがあれば、ここで個別にコピーします
-# 例: COPY src/ ./src/
 
 # ライブラリのインストール
 RUN pip install --no-cache-dir --upgrade pip
 
-# PyTorch のインストール（CPU 版の軽量ホイールを指定）
-RUN pip install --no-cache-dir https://download.pytorch.org/whl/cpu/torch-2.1.0%2Bcpu-cp311-cp311-linux_x86_64.whl
+# PyTorch のインストール（ホイールファイルをダウンロードしてインストール）
+RUN curl -L -o torch-2.5.1+cpu.cxx11.abi-cp311-cp311-linux_x86_64.whl \
+    "https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.1%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl" && \
+    pip install --no-cache-dir torch-2.5.1+cpu.cxx11.abi-cp311-cp311-linux_x86_64.whl && \
+    rm torch-2.5.1+cpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
 
 # 他の依存関係をインストール
 RUN pip install --no-cache-dir -r requirements.txt
@@ -68,8 +69,6 @@ COPY --from=builder /usr/local /usr/local
 
 # 必要なファイルのみをコピー
 COPY process_issues.py ./
-# 他に必要なファイルがあれば、ここで個別にコピーします
-# 例: COPY src/ ./src/
 
 # キャッシュの削除（念のため）
 RUN rm -rf /root/.cache/pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ WORKDIR /app
 # 必要なファイルのみをコピー
 COPY requirements.txt ./
 COPY process_issues.py ./
+COPY convert_model.py ./
+COPY readme_generator.py ./
 
 # ライブラリのインストール
 RUN pip install --no-cache-dir --upgrade pip
@@ -69,6 +71,8 @@ COPY --from=builder /usr/local /usr/local
 
 # 必要なファイルのみをコピー
 COPY process_issues.py ./
+COPY convert_model.py ./
+COPY readme_generator.py ./
 
 # キャッシュの削除（念のため）
 RUN rm -rf /root/.cache/pip \

--- a/process_issues.py
+++ b/process_issues.py
@@ -111,13 +111,19 @@ def main(repository, run_id):
         print("処理すべきモデル変換の Issue はありません。")
 
 def check_for_duplicate_issue(g, title, current_issue_number, repository):
-    query = f'"{title}" in:title is:closed repo:{repository}'
+    # タイトルに含まれる単語で検索範囲を狭める（不要な場合があるため、場合によっては削除してもよい）
+    keywords = title.strip().split('/')
+    query = f'repo:{repository} is:issue is:closed'
+    for keyword in keywords:
+        query += f' {keyword} in:title'
+
     issues = g.search_issues(query)
     for issue in issues:
         issue_number = issue.number
         issue_labels = [label.name for label in issue.labels]
-        # "Completed" ラベルが付いている Issue を対象とする
-        if "Completed" in issue_labels and issue_number != current_issue_number:
+        issue_title = issue.title.strip()
+        # タイトルが完全一致し、"Completed" ラベルが付いている Issue を対象とする
+        if issue_title == title.strip() and "Completed" in issue_labels and issue_number != current_issue_number:
             return issue_number  # 重複する過去の Issue の番号を返す
 
     return None  # 重複する Issue が見つからなかった

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
 certifi==2024.12.14
+cffi==1.17.1
 charset-normalizer==3.4.0
 colorama==0.4.6
 coloredlogs==15.0.1
-filelock==3.16.1
+cryptography==44.0.0
+deprecated==1.2.15
+filelock==3.13.1
 flatbuffers==24.3.25
-fsspec==2024.10.0
+fsspec==2024.2.0
 huggingface-hub==0.27.0
 humanfriendly==10.0
 idna==3.10
@@ -25,6 +28,10 @@ protobuf==3.20.2
 psutil==6.1.0
 py-cpuinfo==9.0.0
 py3nvml==0.2.7
+pycparser==2.22
+pygithub==2.5.0
+pyjwt==2.10.1
+pynacl==1.5.0
 pyreadline3==3.5.4
 pyyaml==6.0.2
 regex==2024.11.6
@@ -35,7 +42,8 @@ tokenizers==0.21.0
 torch==2.5.1
 tqdm==4.67.1
 transformers==4.47.1
-typing-extensions==4.12.2
+typing-extensions==4.9.0
 urllib3==2.2.3
 wcwidth==0.2.13
+wrapt==1.17.0
 xmltodict==0.14.2


### PR DESCRIPTION
fixed #25 

**docker imageを14GBから1.36GBまで縮小**
* pytorchをwhlを使用
* docker fileをマルチステージで分散
* 実行速度が6分から3分程度に短縮

**actionsにdockerのcache機能の追加**
* gh CLIに依存しない実装に変更 ( [[PyGithub](https://github.com/PyGithub/PyGithub)] を使用)

**issueの重複判定**
